### PR TITLE
Fixes pre-commit (caching+ more)

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   pre-commit:
+
+    name: Pre-commit
+
     runs-on: ubuntu-latest
 
     steps:
@@ -19,5 +22,18 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
 
+      - name: Cache R packages for pre-commit (live in renv)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/R/renv
+          key: r-precommit-cache|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+
+      # Notice this step depends on what
+      # https://github.com/lorenzwalthert/precommit has as
+      # R version in renv.lock. GHA ubuntu-latest runner comes
+      # with R 4.4.1, which is the same as in renv.lock. If that
+      # changes, caching will not work as it will be loading a
+      # different version of R.
       - name: Run pre-commit hooks
         uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,8 @@ repos:
           [
             '--ignore-start="^# styler: off$"',
             '--ignore-stop="^# styler: on$"',
-            '--strict=FALSE'
+            '--strict=FALSE',
+            '--cache-root=styler-perm'
             ]
       - id: lintr
         args: [--warn_only]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     -   id: detect-private-key
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.4.2
+    rev: v0.4.3
     hooks:
       - id: style-files
         args:


### PR DESCRIPTION
This pull request includes updates to the pre-commit workflow and configuration files to improve caching and update dependencies. The most important changes involve adding caching for R packages, updating the version of the `precommit` repository, and modifying arguments for style checks.

Enhancements to pre-commit workflow:

* [`.github/workflows/pre-commit.yaml`](diffhunk://#diff-3c0d80ea54e617ba55ba031dda6fc983852272f93775375ce402a66a03560548R25-R37): Added a step to cache R packages using `actions/cache@v4` to improve efficiency.
* [`.github/workflows/pre-commit.yaml`](diffhunk://#diff-3c0d80ea54e617ba55ba031dda6fc983852272f93775375ce402a66a03560548R13-R15): Added a name to the pre-commit job for better readability.

Updates to pre-commit configuration:

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L14-R22): Updated the `precommit` repository version from `v0.4.2` to `v0.4.3` to incorporate the latest changes and improvements.
* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L14-R22): Added `--cache-root=styler-perm` argument to the `style-files` hook to specify a permanent cache location.